### PR TITLE
fix: ensure all assert.Equals have expected first

### DIFF
--- a/pkg/childminder/childminder_test.go
+++ b/pkg/childminder/childminder_test.go
@@ -23,7 +23,7 @@ func Test_Run(t *testing.T) {
 	assert.Nil(t, err, "Got an error")
 	assert.NotNil(t, out, "out was nil")
 	output := *out
-	assert.Equal(t, output, expected)
+	assert.Equal(t, expected, output)
 }
 
 func Test_Run_invalid_working_dir(t *testing.T) {
@@ -46,5 +46,5 @@ func Test_Run_silently(t *testing.T) {
 	assert.Nil(t, err, "Got an error")
 	assert.NotNil(t, out, "out was nil")
 	output := *out
-	assert.Equal(t, output, expected)
+	assert.Equal(t, expected, output)
 }

--- a/pkg/simulator/terraform_output_test.go
+++ b/pkg/simulator/terraform_output_test.go
@@ -1,11 +1,12 @@
 package simulator_test
 
 import (
-	"github.com/kubernetes-simulator/simulator/pkg/simulator"
-	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"os"
 	"testing"
+
+	"github.com/kubernetes-simulator/simulator/pkg/simulator"
+	"github.com/stretchr/testify/assert"
 )
 
 func fixture(name string) string {
@@ -92,7 +93,7 @@ Host node-1 127.0.0.3
 	assert.Nil(t, err, "Got an error")
 	assert.NotNil(t, out, "Got nil output")
 
-	assert.Equal(t, *out, expected, "SSH config was not correct")
+	assert.Equal(t, expected, *out, "SSH config was not correct")
 }
 
 func Test_ParseTerraformOutput(t *testing.T) {
@@ -103,9 +104,9 @@ func Test_ParseTerraformOutput(t *testing.T) {
 
 	assert.Nil(t, err, "Got an error")
 	assert.NotNil(t, tfOutput, "Output was nil")
-	assert.Equal(t, tfOutput.BastionPublicIP.Value, "34.244.109.234", "Bastion IP was wrong")
-	assert.Equal(t, len(tfOutput.ClusterNodesPrivateIP.Value), 1, "Didn't get 1 node IP")
-	assert.Equal(t, tfOutput.ClusterNodesPrivateIP.Value[0], "172.31.2.19")
-	assert.Equal(t, len(tfOutput.MasterNodesPrivateIP.Value), 1, "Didn't get 1 master IP")
-	assert.Equal(t, tfOutput.MasterNodesPrivateIP.Value[0], "172.31.2.167")
+	assert.Equal(t, "34.244.109.234", tfOutput.BastionPublicIP.Value, "Bastion IP was wrong")
+	assert.Equal(t, 1, len(tfOutput.ClusterNodesPrivateIP.Value), "Didn't get 1 node IP")
+	assert.Equal(t, "172.31.2.19", tfOutput.ClusterNodesPrivateIP.Value[0])
+	assert.Equal(t, 1, len(tfOutput.MasterNodesPrivateIP.Value), "Didn't get 1 master IP")
+	assert.Equal(t, "172.31.2.167", tfOutput.MasterNodesPrivateIP.Value[0])
 }

--- a/pkg/simulator/terraform_test.go
+++ b/pkg/simulator/terraform_test.go
@@ -1,12 +1,13 @@
 package simulator_test
 
 import (
+	"testing"
+
 	sim "github.com/kubernetes-simulator/simulator/pkg/simulator"
 	"github.com/kubernetes-simulator/simulator/pkg/ssh"
 	"github.com/kubernetes-simulator/simulator/pkg/util"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
-	"testing"
 
 	"io/ioutil"
 	"os"
@@ -38,7 +39,7 @@ func Test_PrepareTfArgs(t *testing.T) {
 
 	for _, tt := range tfCommandArgumentsTests {
 		t.Run("Test arguments for "+tt.prepArgs[0], func(t *testing.T) {
-			assert.Equal(t, simulator.PrepareTfArgs(tt.prepArgs[0]), tt.arguments)
+			assert.Equal(t, tt.arguments, simulator.PrepareTfArgs(tt.prepArgs[0]))
 		})
 	}
 }
@@ -64,7 +65,6 @@ func Test_Status(t *testing.T) {
 }
 
 func Test_Create(t *testing.T) {
-
 	pwd, _ := os.Getwd()
 	logger.Out = ioutil.Discard
 	simulator := sim.NewSimulator(

--- a/pkg/ssh/ssh_test.go
+++ b/pkg/ssh/ssh_test.go
@@ -21,5 +21,5 @@ func Test_EnsureKey_and_GetAuthMethods(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.NotNil(t, auths)
-	assert.Equal(t, len(auths), 1)
+	assert.Equal(t, 1, len(auths))
 }

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -47,7 +47,7 @@ func Test_DetectPublicIP(t *testing.T) {
 func Test_EnvOrDefault(t *testing.T) {
 	key := "SIMULATOR_TEST_" + string(time.Now().Unix())
 	defaulted := util.EnvOrDefault(key, "setting")
-	assert.Equal(t, defaulted, "setting", "Did not return default")
+	assert.Equal(t, "setting", defaulted, "Did not return default")
 
 	os.Setenv(key, "custom")
 	val := util.EnvOrDefault(key, "custom")


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows the conventional commits guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix - ensure consistent / correct test output.

* **What is the current behavior?** (You can also link to an open issue here)
Some assert.Equals calls mistakenly use (actual, expected) instead of (expected, actual).

* **What is the new behavior (if this is a feature change)?**
Ensure consistent use of assert.Equals() with expected value first.
[Docs](https://pkg.go.dev/github.com/stretchr/testify/assert#Equal)

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.

* **Other information**:
