### PR TITLE
fix(build): linter read Go version from go.mod

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,6 +22,7 @@ jobs:
         uses: reviewdog/action-golangci-lint@v2
         with:
           golangci_lint_flags: "--config=./.golangci.yml --timeout=6m0s"
+          go_version_file: go.mod
 
       - name: Setup Go
         uses: actions/setup-go@v4

--- a/.trivy-config/.trivyignore
+++ b/.trivy-config/.trivyignore
@@ -28,3 +28,4 @@ CVE-2022-32149
 CVE-2023-49568
 ## Ignoring as it has not been patched in the upstream binary
 GHSA-9763-4f94-gfch
+CVE-2023-49569


### PR DESCRIPTION
- fix build fails due to golangci-lint using the latest version of Go instead of the one in the go.mod file
- Add exception for the CVE in the packer binary that hasn't been fixed upstream yet