### PR TITLE
feat: ensure errors are logged using slog

### DIFF
--- a/cmd/container/main.go
+++ b/cmd/container/main.go
@@ -5,11 +5,10 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/spf13/cobra"
-
 	"github.com/controlplaneio/simulator/v2/core/tools"
 	"github.com/controlplaneio/simulator/v2/internal/cli"
 	"github.com/controlplaneio/simulator/v2/internal/config"
+	"github.com/controlplaneio/simulator/v2/internal/logging"
 )
 
 func main() {
@@ -75,6 +74,7 @@ func main() {
 		),
 	)
 
-	err := simulator.Execute()
-	cobra.CheckErr(err)
+	if err := simulator.Execute(); err != nil {
+		logging.LogFatal("Simulator CLI returned an error", err)
+	}
 }

--- a/cmd/simulator/main.go
+++ b/cmd/simulator/main.go
@@ -6,13 +6,12 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/spf13/cobra"
-
 	"github.com/controlplaneio/simulator/v2/core/aws"
 	"github.com/controlplaneio/simulator/v2/core/tools"
 	"github.com/controlplaneio/simulator/v2/internal/cli"
 	"github.com/controlplaneio/simulator/v2/internal/config"
 	"github.com/controlplaneio/simulator/v2/internal/docker"
+	"github.com/controlplaneio/simulator/v2/internal/logging"
 )
 
 const (
@@ -167,8 +166,9 @@ func main() {
 		}),
 	)
 
-	err = simulator.Execute()
-	cobra.CheckErr(err)
+	if err := simulator.Execute(); err != nil {
+		logging.LogFatal("Simulator CLI returned an error", err)
+	}
 }
 
 func mkDirsIfNotExist(dirs ...string) {

--- a/internal/cli/bucket.go
+++ b/internal/cli/bucket.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"os"
 
@@ -29,7 +30,7 @@ func WithBucketCmd(opts ...SimulatorCmdOptions) SimulatorCmdOptions {
 func WithCreateBucketCmd(config config.Config, manager aws.BucketManager) SimulatorCmdOptions {
 	bucketCreateCommand := &cobra.Command{
 		Use: "create",
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			ctx := context.Background()
 
 			if config.Bucket == "" {
@@ -38,7 +39,10 @@ func WithCreateBucketCmd(config config.Config, manager aws.BucketManager) Simula
 			}
 
 			err := manager.Create(ctx, config.Bucket)
-			cobra.CheckErr(err)
+			if err != nil {
+				return fmt.Errorf("unable to create bucket: %w", err)
+			}
+			return nil
 		},
 	}
 
@@ -50,11 +54,14 @@ func WithCreateBucketCmd(config config.Config, manager aws.BucketManager) Simula
 func WithDeleteBucketCmd(config config.Config, manager aws.BucketManager) SimulatorCmdOptions {
 	bucketCreateCommand := &cobra.Command{
 		Use: "delete",
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			ctx := context.Background()
 
 			err := manager.Delete(ctx, config.Bucket)
-			cobra.CheckErr(err)
+			if err != nil {
+				return fmt.Errorf("unable to delete bucket: %w", err)
+			}
+			return nil
 		},
 	}
 

--- a/internal/cli/container.go
+++ b/internal/cli/container.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/spf13/cobra"
 
@@ -28,10 +29,13 @@ func WithContainerPullCmd(config config.Config, client *docker.Client) Simulator
 	imagePullCmd := &cobra.Command{
 		Use:   "pull",
 		Short: "Pull the Simulator Container Image",
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			err := client.PullImage(ctx, config.Container.Image)
-			cobra.CheckErr(err)
+			if err != nil {
+				return fmt.Errorf("unable to pull simulator container image: %w", err)
+			}
+			return nil
 		},
 	}
 

--- a/internal/cli/scenario.go
+++ b/internal/cli/scenario.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"os/signal"
 
@@ -31,11 +32,14 @@ func WithScenarioListCmd() SimulatorCmdOptions {
 	scenarioListCmd := &cobra.Command{
 		Use:   "list",
 		Short: "List available scenarios",
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			list, err := scenarios.List()
-			cobra.CheckErr(err)
+			if err != nil {
+				return fmt.Errorf("unable to list available scenarios: %w", err)
+			}
 
 			tabulateScenarios(list)
+			return nil
 		},
 	}
 
@@ -49,13 +53,16 @@ func WithScenarioDescribeCmd() SimulatorCmdOptions {
 		Use:   "describe [id]",
 		Short: "Describes a scenario",
 		Args:  cobra.MinimumNArgs(1),
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(_ *cobra.Command, args []string) error {
 			scenarioID := args[0]
 
 			s, err := scenarios.Find(scenarioID)
-			cobra.CheckErr(err)
+			if err != nil {
+				return fmt.Errorf("unable to describe scenario: %w", err)
+			}
 
 			tabulateScenarios([]scenarios.Scenario{s})
+			return nil
 		},
 	}
 
@@ -69,13 +76,16 @@ func WithScenarioInstallCmd(manager tools.ScenarioManager) SimulatorCmdOptions {
 		Use:   "install [id]",
 		Short: "Install the scenario into the simulator infrastructure",
 		Args:  cobra.MinimumNArgs(1),
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(_ *cobra.Command, args []string) error {
 			ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
 			defer stop()
 
 			scenarioID := args[0]
 			err := manager.Install(ctx, scenarioID)
-			cobra.CheckErr(err)
+			if err != nil {
+				return fmt.Errorf("unable to install the scenario: %w", err)
+			}
+			return nil
 		},
 	}
 
@@ -89,13 +99,16 @@ func WithScenarioUninstallCmd(manager tools.ScenarioManager) SimulatorCmdOptions
 		Use:   "uninstall [id]",
 		Short: "Uninstall the scenario from the simulator infrastructure",
 		Args:  cobra.MinimumNArgs(1),
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(_ *cobra.Command, args []string) error {
 			ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
 			defer stop()
 
 			scenarioID := args[0]
 			err := manager.Uninstall(ctx, scenarioID)
-			cobra.CheckErr(err)
+			if err != nil {
+				return fmt.Errorf("unable to uninstall the scenario: %w", err)
+			}
+			return nil
 		},
 	}
 

--- a/internal/cli/simulator.go
+++ b/internal/cli/simulator.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/controlplaneio/simulator/v2/internal/logging"
@@ -22,12 +23,18 @@ func NewSimulatorCmd(opts ...SimulatorCmdOptions) *cobra.Command {
 
 	simulator.PersistentFlags().String("log-level", logLevel(), "Log level (error, warn, info, debug)")
 
-	simulator.PersistentPreRun = func(cmd *cobra.Command, _ []string) {
-		logLevel, err := cmd.Flags().GetString("log-level")
-		cobra.CheckErr(err)
+	simulator.PersistentPreRunE = func(cmd *cobra.Command, _ []string) error {
+		logLevel, err := cmd.Flags().GetString("log-level222")
+		if err != nil {
+			return fmt.Errorf("unable to get log-level flag: %w", err)
+		}
 
 		err = logging.Configure(logLevel)
-		cobra.CheckErr(err)
+		if err != nil {
+			return fmt.Errorf("unable to configure logging: %w", err)
+		}
+
+		return nil
 	}
 
 	for _, opt := range opts {

--- a/internal/logging/factory.go
+++ b/internal/logging/factory.go
@@ -32,3 +32,8 @@ func Configure(level string) error {
 
 	return nil
 }
+
+func LogFatal(msg string, err error) {
+	slog.Error(msg, "error", err)
+	os.Exit(1)
+}


### PR DESCRIPTION
This commit removes the usage of cobra.CheckError in favor of returning errors to the caller and log errors using slog.