### PR TITLE
fix(terraform): remove ForwardAgent on from ssh_client config

### DIFF
--- a/terraform/modules/ssh-config/templates/ssh_config
+++ b/terraform/modules/ssh-config/templates/ssh_config
@@ -4,7 +4,6 @@ Host bastion ${bastion_ip}
 %{if ssh_force_tty ~}
     RequestTTY force
 %{endif ~}
-    ForwardAgent yes
     IdentityFile ${ssh_identity_file}
     UserKnownHostsFile ${ssh_known_hosts}
 %{ for id in keys(instances) ~}


### PR DESCRIPTION
having ssh ForwardAgent on imposes a security risk. It is not necessary in this use-case and will perfectly work without ForwardAgent in the ssh_config.

fixes: #396 